### PR TITLE
commons enum type & commons domains BaseEntity & domain skeleton code…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,20 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+//	runtimeOnly 'com.h2database:h2'
+
+	testImplementation'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	compileOnly 'org.projectlombok:lombok:1.18.28'
+	annotationProcessor 'org.projectlombok:lombok:1.18.28'
+
+	testCompileOnly 'org.projectlombok:lombok:1.18.28'
+	testAnnotationProcessor 'org.projectlombok:lombok:1.18.28'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/Ildeurim/commons/domains/BaseEntity.java
+++ b/src/main/java/com/example/Ildeurim/commons/domains/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.Ildeurim.commons.domains;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // 상속받는 엔티티에 매핑 정보 제공
+@EntityListeners(AuditingEntityListener.class) // 엔티티 변경 감지
+public abstract class BaseEntity {
+
+    @CreatedDate // 엔티티 최초 생성 시 자동 저장
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate // 엔티티 값 변경 시 자동 저장
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/Ildeurim/commons/enums/Hashtag.java
+++ b/src/main/java/com/example/Ildeurim/commons/enums/Hashtag.java
@@ -1,0 +1,53 @@
+package com.example.Ildeurim.commons.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Hashtag {
+
+    // 긍정적
+    FRIENDLY_ATMOSPHERE("친절한 분위기"),
+    CLEAN_ENVIRONMENT("청결한 환경"),
+    GOOD_COMMUNICATION("원활한 소통"),
+    FAIR_WAGE("합리적인 급여"),
+    FLEXIBLE_SCHEDULE("유연한 근무시간"),
+    SUPPORTIVE_MANAGEMENT("배려 깊은 경영진"),
+    SKILL_IMPROVEMENT("역량 향상 기회"),
+    GOOD_TEAMWORK("팀워크가 좋음"),
+    POSITIVE_FEEDBACK("긍정적인 피드백"),
+    STABLE_WORK("안정적인 업무"),
+
+    // 중립적
+    REGULAR_TASKS("규칙적인 업무"),
+    AVERAGE_PAY("평균적인 급여"),
+    BASIC_TRAINING("기본 교육 제공"),
+    NORMAL_WORKLOAD("평범한 업무량"),
+    FIXED_SCHEDULE("정해진 근무시간"),
+    STANDARD_RULES("표준 규정 준수"),
+    CLEAR_INSTRUCTIONS("명확한 지시"),
+    SIMPLE_TASKS("단순한 업무"),
+    ADEQUATE_RESOURCES("충분한 자원"),
+    AVERAGE_ENVIRONMENT("보통의 환경"),
+
+    // 부정적
+    LONG_HOURS("긴 근무시간"),
+    LOW_PAY("낮은 급여"),
+    POOR_MANAGEMENT("미흡한 경영"),
+    LACK_OF_COMMUNICATION("소통 부족"),
+    UNSAFE_ENVIRONMENT("위험한 작업환경"),
+    HIGH_STRESS("높은 업무강도"),
+    LACK_OF_SUPPORT("지원 부족"),
+    UNFAIR_TREATMENT("불공정한 대우"),
+    LACK_OF_RESOURCES("부족한 자원"),
+    MONOTONOUS_WORK("단조로운 업무");
+
+    private final String label;
+
+    Hashtag(String label) {
+        this.label = label;
+    }
+
+    @JsonValue // JSON 직렬화 시 label 값이 반환되도록 함
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/example/Ildeurim/commons/enums/PaymentType.java
+++ b/src/main/java/com/example/Ildeurim/commons/enums/PaymentType.java
@@ -1,0 +1,32 @@
+package com.example.Ildeurim.commons.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum PaymentType {
+    HOURLY("시급"),
+    DAILY("일급"),
+    MONTHLY("월급"),
+    PER_TASK("건당");
+
+
+    private final String label;
+
+    PaymentType(String label) {
+        this.label = label;
+    }
+
+    @JsonValue // JSON 직렬화 시 label 값이 반환되도록 함
+    public String getLabel() {
+        return label;
+    }
+    @JsonCreator
+    public static PaymentType fromLabel(String label) {
+        for (PaymentType type : values()) {
+            if (type.label.equals(label)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown PaymentType label: " + label);
+    }
+}

--- a/src/main/java/com/example/Ildeurim/commons/enums/UserType.java
+++ b/src/main/java/com/example/Ildeurim/commons/enums/UserType.java
@@ -1,0 +1,4 @@
+package com.example.Ildeurim.commons.enums;
+
+public enum UserType {
+}

--- a/src/main/java/com/example/Ildeurim/domain/Application.java
+++ b/src/main/java/com/example/Ildeurim/domain/Application.java
@@ -1,0 +1,18 @@
+package com.example.Ildeurim.domain;
+
+import com.example.Ildeurim.commons.domains.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Application extends BaseEntity {
+    @Id // id 필드를 기본키(Primary Key)로 지정
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+}

--- a/src/main/java/com/example/Ildeurim/domain/Career.java
+++ b/src/main/java/com/example/Ildeurim/domain/Career.java
@@ -1,0 +1,18 @@
+package com.example.Ildeurim.domain;
+
+import com.example.Ildeurim.commons.domains.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Career extends BaseEntity {
+    @Id // id 필드를 기본키(Primary Key)로 지정
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+}

--- a/src/main/java/com/example/Ildeurim/domain/Employer.java
+++ b/src/main/java/com/example/Ildeurim/domain/Employer.java
@@ -1,0 +1,18 @@
+package com.example.Ildeurim.domain;
+
+import com.example.Ildeurim.commons.domains.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Employer extends BaseEntity {
+    @Id // id 필드를 기본키(Primary Key)로 지정
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+}

--- a/src/main/java/com/example/Ildeurim/domain/Job.java
+++ b/src/main/java/com/example/Ildeurim/domain/Job.java
@@ -1,0 +1,18 @@
+package com.example.Ildeurim.domain;
+
+import com.example.Ildeurim.commons.domains.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Job extends BaseEntity {
+    @Id // id 필드를 기본키(Primary Key)로 지정
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+}

--- a/src/main/java/com/example/Ildeurim/domain/JobPost.java
+++ b/src/main/java/com/example/Ildeurim/domain/JobPost.java
@@ -1,0 +1,18 @@
+package com.example.Ildeurim.domain;
+
+import com.example.Ildeurim.commons.domains.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JobPost extends BaseEntity {
+    @Id // id 필드를 기본키(Primary Key)로 지정
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+}

--- a/src/main/java/com/example/Ildeurim/domain/Review.java
+++ b/src/main/java/com/example/Ildeurim/domain/Review.java
@@ -1,4 +1,49 @@
 package com.example.Ildeurim.domain;
+import com.example.Ildeurim.commons.domains.BaseEntity;
+import com.example.Ildeurim.commons.enums.Hashtag;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
-public class Review {
+import java.util.List;
+
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Review extends BaseEntity {
+    @Id // id 필드를 기본키(Primary Key)로 지정
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="workerId", nullable = false)
+    @OnDelete(action= OnDeleteAction.CASCADE)
+    private Worker worker;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employerId", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Employer employer;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ElementCollection(targetClass = Hashtag.class)
+    @CollectionTable(
+            name = "hashtags", // 별도 테이블 이름
+            joinColumns = @JoinColumn(name = "reviewId") // 연결 컬럼
+    )
+    @Enumerated(EnumType.STRING) // enum을 문자열로 저장
+    @Column(name = "hashtag", nullable = false)
+    private List<Hashtag> hashtags;
+
 }

--- a/src/main/java/com/example/Ildeurim/domain/Worker.java
+++ b/src/main/java/com/example/Ildeurim/domain/Worker.java
@@ -1,0 +1,18 @@
+package com.example.Ildeurim.domain;
+
+import com.example.Ildeurim.commons.domains.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Worker extends BaseEntity {
+    @Id // id 필드를 기본키(Primary Key)로 지정
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(updatable = false)
+    private Long id;
+}

--- a/src/main/java/com/example/Ildeurim/dto/ReviewResponse.java
+++ b/src/main/java/com/example/Ildeurim/dto/ReviewResponse.java
@@ -1,4 +1,0 @@
-package com.example.Ildeurim.dto;
-
-public class ReviewResponse {
-}

--- a/src/main/java/com/example/Ildeurim/dto/review/ReviewCreateReq.java
+++ b/src/main/java/com/example/Ildeurim/dto/review/ReviewCreateReq.java
@@ -1,0 +1,19 @@
+package com.example.Ildeurim.dto.review;
+
+import com.example.Ildeurim.commons.enums.Hashtag;
+import jakarta.validation.constraints.*;
+import org.hibernate.validator.constraints.UniqueElements;
+
+import java.util.List;
+
+/**
+ * 리뷰 생성 요청 DTO
+ * - 로그인 중인 workerId는 DTO에 포함하지 않고 SecurityContext에서 읽음.
+ * - EMPLOYER에 대한 리뷰만 허용
+ */
+public record ReviewCreateReq(
+        @NotNull Long targetId,// employerId
+        @NotNull @Min(1) @Max(5) Integer rating,
+        @NotBlank @Size(max = 1000) String content,
+        @Size(max = 5) @UniqueElements List<Hashtag> hashtags
+) {}

--- a/src/main/java/com/example/Ildeurim/dto/review/ReviewFilter.java
+++ b/src/main/java/com/example/Ildeurim/dto/review/ReviewFilter.java
@@ -1,0 +1,4 @@
+package com.example.Ildeurim.dto.review;
+
+public class ReviewFilter {
+}

--- a/src/main/java/com/example/Ildeurim/dto/review/ReviewRes.java
+++ b/src/main/java/com/example/Ildeurim/dto/review/ReviewRes.java
@@ -1,0 +1,49 @@
+package com.example.Ildeurim.dto.review;
+
+import com.example.Ildeurim.commons.enums.Hashtag;
+import com.example.Ildeurim.domain.Review;
+import com.fasterxml.jackson.annotation.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReviewRes {
+
+    private Long id;
+
+    // 리뷰 대상 employerId
+    private Long targetId;
+
+    // 본문
+    private Integer rating;        // 1~5
+    private String content;
+    private List<Hashtag> hashtags; // @JsonValue 설정되어 있다면 라벨로 직렬화됨
+
+    // 작성자/감사 정보(필요하면 노출)
+    private Long workerId;         // 로그인한 작성자 id
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    /**
+     * 엔티티 → DTO 변환 헬퍼 (편의용)
+     */
+    public static ReviewRes from(Review review) {
+        return ReviewRes.builder()
+                .id(review.getId())
+                .targetId(review.getEmployer().getId())
+                .rating(review.getRating())
+                .content(review.getContent())
+                .hashtags(review.getHashtags())
+                .workerId(review.getWorker().getId())
+                .createdAt(review.getCreatedAt() == null ? null : review.getCreatedAt().atOffset(ZoneOffset.UTC))
+                .updatedAt(review.getUpdatedAt() == null ? null : review.getUpdatedAt().atOffset(ZoneOffset.UTC))
+                .build();
+    }
+}

--- a/src/main/java/com/example/Ildeurim/dto/review/ReviewUpdateReq.java
+++ b/src/main/java/com/example/Ildeurim/dto/review/ReviewUpdateReq.java
@@ -1,0 +1,28 @@
+package com.example.Ildeurim.dto.review;
+
+import com.example.Ildeurim.commons.enums.Hashtag;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+import java.util.List;
+
+/**
+ * 리뷰 업데이트 요청 DTO
+ * - 모든 필드는 optional
+ * - null이 아닌 값만 서비스 계층에서 업데이트 적용
+ */
+@Builder
+public record ReviewUpdateReq(
+
+        @Nullable
+        @Min(1) @Max(5)
+        Integer rating, // 별점 (1~5)
+
+        @Nullable
+        String content, // 리뷰 내용
+
+        @Nullable
+        List<Hashtag> hashtag // 해시태그 목록 (최대 N개)
+) {
+}


### PR DESCRIPTION
### commons enum type
- package commons/enums/ 위치에 프로젝트에서 사용할 커스텀 enum type을 구현하였습니다.
### commons domains BaseEntity
- package commons/domains/ 위치에 모든 entity class가 createdAt, updatedAt 필드를 자동으로 가질 수 있도록 BaseEntity 추상 클래스를 구현하였습니다. BaseEntity를 상속받아 구현하면 중복 코드 없이  createdAt, updatedAt 필드를 가지도록 할 수 있습니다.
### domain skeleton code
- 현재 ERD에서 정의한 모든 domain에 대해 스켈레톤 코드를 작성하였습니다. 실제 구현은 제가 맡은 Review에 대해서만 진행되어있고 나머지는 빈 템플릿입니다. 각자 맡은 도메인에 대해 구현 진행해주시면 됩니다.
### Review dto
- 제가 맡은 Review 도메인에 대해 API 명세서에서 정의한 ReviewCreateReq, ReviewUpdateReq, ReviewRes, ReviewFilter(미구현)을 구현하였습니다. ReviewFilter의 경우 디자인이 확정된 후에 구현 진행할 예정입니다.


코드 오류 등 이상한 점이나 궁금한 점 있으시면 바로 카톡으로 알려주시면 감사하겠습니다!