### PR TITLE
Hyeonseo

### DIFF
--- a/src/main/java/com/example/Ildeurim/controller/EmployerController.java
+++ b/src/main/java/com/example/Ildeurim/controller/EmployerController.java
@@ -2,11 +2,15 @@ package com.example.Ildeurim.controller;
 
 import com.example.Ildeurim.auth.AuthContext;
 import com.example.Ildeurim.dto.ApiResponse;
+import com.example.Ildeurim.dto.career.CareerRes;
 import com.example.Ildeurim.dto.employer.*;
+import com.example.Ildeurim.service.CareerService;
 import com.example.Ildeurim.service.EmployerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class EmployerController {
 
     private final EmployerService employerService;
+    private final CareerService careerService;
 
     @PostMapping
     public ResponseEntity<ApiResponse> createEmployer(@RequestBody EmployerCreateReq req) {
@@ -26,6 +31,12 @@ public class EmployerController {
     public ResponseEntity<ApiResponse> me() {
         EmployerDetailRes res = employerService.me();
         return ResponseEntity.ok(new ApiResponse(true, 201, "get employer me success", res));
+    }
+
+    @GetMapping("/{workerId}/careers")
+    public ResponseEntity<ApiResponse> getWorkerCareers(@PathVariable Long workerId) {
+        List<CareerRes> res = careerService.getWorkerPublicCareerList(workerId);
+        return ResponseEntity.ok(new ApiResponse(true, 200, "get employer careers", res));
     }
 
     @PatchMapping("/me")

--- a/src/main/java/com/example/Ildeurim/controller/WorkerController.java
+++ b/src/main/java/com/example/Ildeurim/controller/WorkerController.java
@@ -3,11 +3,15 @@ package com.example.Ildeurim.controller;
 
 import com.example.Ildeurim.auth.AuthContext;
 import com.example.Ildeurim.dto.ApiResponse;
+import com.example.Ildeurim.dto.career.CareerRes;
 import com.example.Ildeurim.dto.worker.*;
+import com.example.Ildeurim.service.CareerService;
 import com.example.Ildeurim.service.WorkerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static org.springframework.http.ResponseEntity.ok;
 
@@ -16,6 +20,7 @@ import static org.springframework.http.ResponseEntity.ok;
 @RequestMapping(value = "/workers")
 public class WorkerController {
     private final WorkerService workerService;
+    private final CareerService careerService;
 
     @PostMapping
     public ResponseEntity<ApiResponse> createWorker(@RequestBody WorkerCreateReq req) {
@@ -27,6 +32,12 @@ public class WorkerController {
     public ResponseEntity<ApiResponse> me() {
         WorkerDetailRes res = workerService.me();
         return ok(new ApiResponse(true, 201, "get me success", res));
+    }
+
+    @GetMapping("/me/careers")
+    public ResponseEntity<ApiResponse> meCareerList() {
+        List<CareerRes> res = careerService.getWorkerCareerList();
+        return ok(new ApiResponse(true, 201, "get me career success", res));
     }
 
     @PatchMapping("/me")

--- a/src/main/java/com/example/Ildeurim/dto/career/CareerRes.java
+++ b/src/main/java/com/example/Ildeurim/dto/career/CareerRes.java
@@ -1,4 +1,12 @@
 package com.example.Ildeurim.dto.career;
 
-public record CareerRes() {
+import com.example.Ildeurim.domain.Career;
+
+public record CareerRes(
+
+) {
+    public static CareerRes from(Career career) {
+        //TODO: career -> careerRes 매핑 메서드 from 작성
+        return new CareerRes();
+    }
 }

--- a/src/main/java/com/example/Ildeurim/dto/career/CareerRes.java
+++ b/src/main/java/com/example/Ildeurim/dto/career/CareerRes.java
@@ -1,0 +1,4 @@
+package com.example.Ildeurim.dto.career;
+
+public record CareerRes() {
+}

--- a/src/main/java/com/example/Ildeurim/dto/job/JobRes.java
+++ b/src/main/java/com/example/Ildeurim/dto/job/JobRes.java
@@ -1,0 +1,6 @@
+package com.example.Ildeurim.dto.job;
+
+public record JobRes(
+
+) {
+}

--- a/src/main/java/com/example/Ildeurim/repository/CareerRepository.java
+++ b/src/main/java/com/example/Ildeurim/repository/CareerRepository.java
@@ -1,0 +1,12 @@
+package com.example.Ildeurim.repository;
+
+import com.example.Ildeurim.domain.Career;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CareerRepository extends JpaRepository<Career, Long> {
+    List<Career> findByWorker_Id(Long workerId);
+
+    List<Career> findByWorker_IdAndIsOpening(Long workerId, Boolean isOpening);
+}

--- a/src/main/java/com/example/Ildeurim/service/CareerService.java
+++ b/src/main/java/com/example/Ildeurim/service/CareerService.java
@@ -1,0 +1,12 @@
+package com.example.Ildeurim.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CareerService {
+    //TODO: create 메서드 작성
+    //TODO: update 메서드 작성
+    //TODO: delete 메서드 작성
+}

--- a/src/main/java/com/example/Ildeurim/service/CareerService.java
+++ b/src/main/java/com/example/Ildeurim/service/CareerService.java
@@ -1,12 +1,61 @@
 package com.example.Ildeurim.service;
 
+import com.example.Ildeurim.auth.AuthContext;
+import com.example.Ildeurim.commons.enums.UserType;
+import com.example.Ildeurim.domain.Career;
+import com.example.Ildeurim.domain.Worker;
+import com.example.Ildeurim.dto.career.CareerRes;
+import com.example.Ildeurim.dto.worker.WorkerDetailRes;
+import com.example.Ildeurim.repository.CareerRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class CareerService {
+    private final CareerRepository careerRepository;
     //TODO: create 메서드 작성
+
+    //TODO: get 메서드 작성 - worker가 갖는 career들을 List<CareerRes>로 반환
+    @Transactional(readOnly = true)
+    public List<CareerRes> getWorkerCareerList() {
+        Long id = AuthContext.userId()
+                .orElseThrow(() -> new AccessDeniedException("Unauthenticated"));
+        UserType userType = AuthContext.userType()
+                .orElseThrow(() -> new AccessDeniedException("Invalid userType"));
+        if (userType.equals(UserType.WORKER)) {
+            List<Career> careerList = careerRepository.findByWorker_Id(id);
+            return careerList.stream()
+                    .map(CareerRes::from).toList();
+        } else {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "user type is not worker");
+        }
+    }
+
+    //TODO: get 메서드 작성 - employer가 특정 workerId에 대해 공개된 career들을 List<CareerRes>로 반환
+    @Transactional(readOnly = true)
+    public List<CareerRes> getWorkerPublicCareerList(Long id) {
+        Long userId = AuthContext.userId()
+                .orElseThrow(() -> new AccessDeniedException("Unauthenticated"));
+        UserType userType = AuthContext.userType()
+                .orElseThrow(() -> new AccessDeniedException("Invalid userType"));
+        if (userType.equals(UserType.EMPLOYER)) {
+            List<Career> publicCareerList = careerRepository.findByWorker_IdAndIsOpening(id, true);
+            return publicCareerList.stream()
+                    .map(CareerRes::from).toList();
+        } else {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "user type is not employer");
+        }
+
+    }
+
     //TODO: update 메서드 작성
+
     //TODO: delete 메서드 작성
 }

--- a/src/main/java/com/example/Ildeurim/service/EmployerService.java
+++ b/src/main/java/com/example/Ildeurim/service/EmployerService.java
@@ -91,7 +91,7 @@ public class EmployerService {
         Long id = AuthContext.userId()
                 .orElseThrow(() -> new AccessDeniedException("Unauthenticated"));
         Employer employer = employerRepository.findById(id)
-                .get();
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Employer not found"));
         EmployerUpdateCmd cmd = employerUpdateCmdMapper.toCmd(req, jobFieldMapper);
         employer.update(cmd);
         employer = employerRepository.save(employer);

--- a/src/main/java/com/example/Ildeurim/service/JobService.java
+++ b/src/main/java/com/example/Ildeurim/service/JobService.java
@@ -1,0 +1,14 @@
+package com.example.Ildeurim.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JobService {
+    //TODO: create 메서드 작성
+    //TODO: getList 메서드 작성 - worker가 가지는 isWorking=true 상태의 job 리스트 반환
+    //TODO: get 메서드 작성 - id로 job을 찾아서 반환
+    //TODO: update 메서드 작성
+    //TODO: delete 메서드 작성
+}

--- a/src/main/java/com/example/Ildeurim/service/WorkerService.java
+++ b/src/main/java/com/example/Ildeurim/service/WorkerService.java
@@ -87,7 +87,7 @@ public class WorkerService {
         Long id = AuthContext.userId()
                 .orElseThrow(() -> new AccessDeniedException("Unauthenticated"));
         Worker worker = workerRepository.findById(id)
-                .get();
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN, "Worker not found"));
         WorkerUpdateCmd cmd = workerUpdateCmdMapper.toCmd(req, jobFieldMapper, workPlaceMapper);
         worker.update(cmd);
         worker = workerRepository.save(worker);


### PR DESCRIPTION
### `worker` | `employer` getCareer API
- controller, service 계층 코드 작성
  - worker: get 메서드 작성 - worker가 갖는 career들을 List<CareerRes>로 반환
  - employer: get 메서드 작성 - employer가 특정 workerId에 대해 공개된 career들을 List<CareerRes>로 반환
- `CareerRes` DTO 작성 필요
### `worker` | `employer` service update 메서드 에외처리
- findById JPA query `.get()`-> `.orElseThrow()` 변경